### PR TITLE
Added provider adapter for OpenAI-compatible vision APIs

### DIFF
--- a/src/fixxer/config.py
+++ b/src/fixxer/config.py
@@ -7,6 +7,7 @@ Application settings, defaults, and configuration file management.
 
 from __future__ import annotations
 
+import os
 import configparser
 from pathlib import Path
 from datetime import datetime
@@ -18,6 +19,7 @@ from typing import Dict, Any
 
 # --- Ollama / AI Settings ---
 OLLAMA_URL = "http://localhost:11434/api/chat"
+DEFAULT_API_PROVIDER = "ollama"
 DEFAULT_MODEL_NAME = "qwen2.5vl:3b"
 DEFAULT_CRITIQUE_MODEL = "qwen2.5vl:3b"
 
@@ -153,6 +155,18 @@ def load_app_config() -> Dict[str, Any]:
 
     config['pro_mode'] = parser.getboolean(
         'behavior', 'pro_mode', fallback=False
+    )
+
+    # --- API / Provider Settings ---
+    # Priority: Env Vars > Config File > Defaults
+    config['api_provider'] = os.environ.get(
+        'FIXXER_API_PROVIDER',
+        parser.get('api', 'provider', fallback=DEFAULT_API_PROVIDER)
+    )
+    
+    config['api_endpoint'] = os.environ.get(
+        'FIXXER_API_ENDPOINT',
+        parser.get('api', 'endpoint', fallback=OLLAMA_URL)
     )
 
     return config

--- a/src/fixxer/vision_providers/__init__.py
+++ b/src/fixxer/vision_providers/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from typing import Dict, Any
+from .base import VisionProvider
+from .ollama import OllamaProvider
+from .openai_compat import OpenAICompatProvider
+
+def get_provider(config_dict: Dict[str, Any]) -> VisionProvider:
+    """
+    Factory function to get the appropriate vision provider based on configuration.
+    """
+    provider_type = config_dict.get("api_provider", "ollama").lower()
+    endpoint = config_dict.get("api_endpoint")
+    
+    if provider_type == "openai":
+        if not endpoint:
+            # Default OpenAI-compatible endpoint (e.g., llama.cpp default)
+            endpoint = "http://localhost:8080/v1/chat/completions"
+        return OpenAICompatProvider(endpoint)
+    else:
+        # Default to Ollama
+        if not endpoint:
+            endpoint = "http://localhost:11434/api/chat"
+        return OllamaProvider(endpoint)

--- a/src/fixxer/vision_providers/base.py
+++ b/src/fixxer/vision_providers/base.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+
+class VisionProvider(ABC):
+    """
+    Abstract base class for vision providers.
+    """
+
+    @abstractmethod
+    def send_request(self, payload: dict, timeout: int) -> str:
+        """
+        Sends a request to the AI model and returns the raw text content.
+
+        Args:
+            payload: The logical intent of the request (messages, model, etc.)
+            timeout: Request timeout in seconds
+
+        Returns:
+            The raw text content from the model's response.
+        """
+        pass
+
+    @abstractmethod
+    def check_connection(self) -> bool:
+        """
+        Checks if the provider is running and accessible.
+
+        Returns:
+            True if accessible, False otherwise.
+        """
+        pass

--- a/src/fixxer/vision_providers/ollama.py
+++ b/src/fixxer/vision_providers/ollama.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import requests
+from .base import VisionProvider
+
+class OllamaProvider(VisionProvider):
+    """
+    Ollama-specific vision provider implementation.
+    """
+
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+
+    def send_request(self, payload: dict, timeout: int) -> str:
+        """
+        Sends a request to Ollama's /api/chat endpoint.
+        """
+        response = requests.post(self.endpoint, json=payload, timeout=timeout)
+        response.raise_for_status()
+        result = response.json()
+        
+        # Ollama /api/chat format: {"message": {"content": "..."}}
+        return result['message']['content']
+
+    def check_connection(self) -> bool:
+        """
+        Checks Ollama connection using /api/tags (stripping /api/chat from endpoint if present).
+        """
+        base_url = self.endpoint.replace("/api/chat", "")
+        tags_url = f"{base_url}/api/tags"
+        
+        try:
+            response = requests.get(tags_url, timeout=3)
+            return response.status_code == 200
+        except Exception:
+            return False

--- a/src/fixxer/vision_providers/openai_compat.py
+++ b/src/fixxer/vision_providers/openai_compat.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+import requests
+from .base import VisionProvider
+
+class OpenAICompatProvider(VisionProvider):
+    """
+    OpenAI-compatible vision provider implementation.
+    Supports llama.cpp, vLLM, LocalAI, etc.
+    """
+
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+
+    def send_request(self, payload: dict, timeout: int) -> str:
+        """
+        Translates Ollama-style payload to OpenAI-compatible format and sends it.
+        """
+        # Translate Ollama payload to OpenAI format
+        messages = []
+        for msg in payload.get("messages", []):
+            role = msg.get("role")
+            content = msg.get("content", "")
+            images = msg.get("images", [])
+            
+            if not images:
+                messages.append({"role": role, "content": content})
+            else:
+                # Build multi-modal content
+                openai_content = [{"type": "text", "text": content}]
+                for img_b64 in images:
+                    # We assume JPEG as it's the default in fixxer's current implementation
+                    openai_content.append({
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:image/jpeg;base64,{img_b64}"
+                        }
+                    })
+                messages.append({"role": role, "content": openai_content})
+
+        openai_payload = {
+            "model": payload.get("model"),
+            "messages": messages,
+            "stream": False
+        }
+        
+        # Add response_format if requested (OpenAI style)
+        if payload.get("format") == "json":
+            openai_payload["response_format"] = {"type": "json_object"}
+
+        response = requests.post(self.endpoint, json=openai_payload, timeout=timeout)
+        response.raise_for_status()
+        result = response.json()
+        
+        # OpenAI format: {"choices": [{"message": {"content": "..."}}]}
+        return result['choices'][0]['message']['content']
+
+    def check_connection(self) -> bool:
+        """
+        Checks connection by pinging the models endpoint.
+        """
+        base_url = self.endpoint.replace("/v1/chat/completions", "")
+        models_url = f"{base_url}/v1/models"
+        
+        try:
+            # Simple GET check
+            response = requests.get(models_url, timeout=3)
+            return response.status_code == 200
+        except Exception:
+            # Fallback: try to just hit the base URL
+            try:
+                response = requests.get(base_url, timeout=3)
+                return response.status_code < 500
+            except Exception:
+                return False


### PR DESCRIPTION
### Summary

Adds support for OpenAI-compatible vision API endpoints (llama.cpp, vLLM, LocalAI, etc.) while keeping Ollama as the default and unchanged.

### Changes

- Introduced a small provider adapter layer to decouple vision API transport.
- Ollama remains the default provider with identical behavior.
- Added OpenAI-compatible `/v1/chat/completions` support.
- Provider selection is config-driven (no UI or workflow changes).

### Usage

Via config file (`~/.fixxer.conf`):
```ini
[api]
provider = openai
endpoint = http://localhost:8080/v1/chat/completions
```
Via environment variables:
```
FIXXER_API_PROVIDER=openai
FIXXER_API_ENDPOINT=http://localhost:8080/v1/chat/completions
```
### Testing

- Verified default Ollama path with no config changes.
- Verified OpenAI-compatible routing and clean failure when endpoint is not running.

Fixes #5 